### PR TITLE
Add Darkmoon

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@
 
 ### Adversary Emulation
 * [Cobalt Strike](https://www.cobaltstrike.com/)
+* [Darkmoon](https://github.com/ASCIT31/Dark-Moon)
 * [Red Team Automation - RTA](https://github.com/endgameinc/RTA)
 * [CALDERA](https://github.com/mitre/caldera)
 * [Atomic Red Team](https://github.com/redcanaryco/atomic-red-team)


### PR DESCRIPTION
Darkmoon is an open-source autonomous AI red team platform with a dedicated Active Directory offensive sub-agent and evidence trail per finding. It fits Adversary Emulation alongside CALDERA and Atomic Red Team.